### PR TITLE
Update to 1.8 nightly

### DIFF
--- a/tests/literals.rs
+++ b/tests/literals.rs
@@ -40,15 +40,6 @@ pub fn utf16_encodes_as_expected() {
 }
 
 #[test]
-pub fn utf16le_encodes_as_expected() {
-    let runtime_encoded = all::UTF_16LE.encode("Test", EncoderTrap::Strict).ok().unwrap();
-    let literal = utf16le!("Test");
-    assert_eq!(runtime_encoded, literal);
-    assert_eq!(['T' as u8, 0, 'e' as u8, 0, 's' as u8, 0, 't' as u8, 0], literal);
-    assert_eq!("Test", all::UTF_16LE.decode(&literal, DecoderTrap::Strict).ok().unwrap());
-}
-
-#[test]
 pub fn utf16be_encodes_as_expected() {
     let runtime_encoded = all::UTF_16BE.encode("Test", EncoderTrap::Strict).ok().unwrap();
     let literal = utf16be!("Test");
@@ -60,12 +51,6 @@ pub fn utf16be_encodes_as_expected() {
 #[test]
 pub fn c_utf16_encodes_as_expected() {
     let literal = c_utf16!("Test");
-    assert_eq!(['T' as u8, 0, 'e' as u8, 0, 's' as u8, 0, 't' as u8, 0, 0, 0], literal);
-}
-
-#[test]
-pub fn c_utf16le_encodes_as_expected() {
-    let literal = c_utf16le!("Test");
     assert_eq!(['T' as u8, 0, 'e' as u8, 0, 's' as u8, 0, 't' as u8, 0, 0, 0], literal);
 }
 


### PR DESCRIPTION
- Using `rustc_plugin`
- Using `get_single_str_from_tts`
- Using `DummyResult::expr` instead of `DummyResult::any`
- Remove macroses with duplicated functional (`utf16le` and `c_utf16le`)
